### PR TITLE
FLUID-5692: Stretch the height of the side bar to the page height.

### DIFF
--- a/src/documents/css/doc-base.css.styl
+++ b/src/documents/css/doc-base.css.styl
@@ -288,7 +288,7 @@ Delete - does not seem to be used?
 .doc-base-start-mainBody {
     margin: 0;
     position: relative;
-    overflow: hidden;
+    overflow: auto;
 }
 
 /* the article body */

--- a/src/documents/css/doc-base.css.styl
+++ b/src/documents/css/doc-base.css.styl
@@ -288,6 +288,7 @@ Delete - does not seem to be used?
 .doc-base-start-mainBody {
     margin: 0;
     position: relative;
+    overflow: hidden;
 }
 
 /* the article body */
@@ -490,6 +491,8 @@ Delete - does not seem to be used?
         padding: 1.5rem;
         width: 25%;
         transition: width transitionTime;
+        padding-bottom: 999rem;
+        margin-bottom: -999rem;
     }
 
     .doc-base-start-articleBody {

--- a/src/layouts/default.html.handlebars
+++ b/src/layouts/default.html.handlebars
@@ -44,7 +44,7 @@
             </div>
             <!-- END markup for Preference Editor -->
 
-            <header class="row doc-base-start-header doc-base-start-header">
+            <header class="row doc-base-start-header">
                 <div class="doc-base-start-logo small-12 medium-5 column">
                     <a class="doc-base-start-logoText" href="{{{getRelativeUrl '/index.html' document.url}}}" title="Doc Base">Doc Base</a>
                 </div>
@@ -114,18 +114,6 @@
 
             <script type="text/javascript">
                 docBase.init("{{{getRelativeUrl '/./' document.url}}}");
-
-                // This code should be refactored into DocBase.js
-                // Also this function should be called each time the hideShow button is pressed since the height changes.
-                $(document).ready(function(){
-                    var sideHeight = $("#side").outerHeight();
-                    var contentHeight = $("#content").outerHeight();
-                    if (sideHeight > contentHeight) {
-                        $("#content").outerHeight(sideHeight);
-                    } else {
-                        $("#side").outerHeight(contentHeight);
-                    }
-                });
             </script>
         </div> <!-- end container -->
 


### PR DESCRIPTION
@jhung, this pull request uses css tricks to stretch the height of the side bar instead of javascript.